### PR TITLE
Update Image Classification of Documents.ipynb

### DIFF
--- a/notebooks/Image Classification of Documents.ipynb
+++ b/notebooks/Image Classification of Documents.ipynb
@@ -97,7 +97,7 @@
     "\n",
     "\n",
     "from sklearn.utils import shuffle\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "from sklearn import preprocessing\n",
     "from skimage import feature, data, io, measure\n",
     "from sklearn.metrics import confusion_matrix\n",


### PR DESCRIPTION
Fixes the 'ImportError: No module named sklearn.cross_validation' error.